### PR TITLE
fix: add -with-bidi variant to internal firefox browsers.json

### DIFF
--- a/build/firefox.go
+++ b/build/firefox.go
@@ -114,7 +114,7 @@ func (c *Firefox) Build() error {
 		}
 		labels = append(labels, fmt.Sprintf("selenoid=%s", selenoidVersion))
 
-		err = writeGeckoBrowsersJSON(image.Dir, firefoxMajorMinorVersion)
+		err = writeGeckoBrowsersJSON(image.Dir, firefoxMajorMinorVersion, withBidiProxy)
 		if err != nil {
 			return fmt.Errorf("failed to write browsers.json: %v", err)
 		}
@@ -252,20 +252,26 @@ func copyFile(src string, dest string) error {
 	return destFile.Sync()
 }
 
-func writeGeckoBrowsersJSON(dir string, version string) error {
-	const template = `{
+func writeGeckoBrowsersJSON(dir string, version string, withBidi bool) error {
+	versionsBlock := fmt.Sprintf(`      "%s": {
+        "image": ["/usr/bin/geckodriver"@@DRIVER_ARGS@@]
+      }`, version)
+	if withBidi {
+		versionsBlock += fmt.Sprintf(`,
+      "%s-with-bidi": {
+        "image": ["/usr/bin/geckodriver"@@DRIVER_ARGS@@]
+      }`, version)
+	}
+	content := fmt.Sprintf(`{
   "firefox": {
     "default": "%s",
     "versions": {
-      "%s": {
-        "image": ["/usr/bin/geckodriver"@@DRIVER_ARGS@@]
-      }
+%s
     }
   }
 }
-`
+`, version, versionsBlock)
 
 	outputPath := filepath.Join(dir, "browsers.json")
-	content := fmt.Sprintf(template, version, version)
 	return os.WriteFile(outputPath, []byte(content), 0644)
 }


### PR DESCRIPTION
Firefox image has an internal selenoid with internal browsers.json. Problem is that if external browsers.json wants to use some custom label like `145.0-with-bidi`, it will fail, because internal browsers.json doesn't know such version.

The solution isn't ideal, but for now I've just add another variant for firefox specifically, so that internal selenoid understood two version formats: `145.0` and `145.0-with-bidi`.